### PR TITLE
Add support for allowing tvheadend to listen on ipv6

### DIFF
--- a/scripts/bin/tvheadend-launch
+++ b/scripts/bin/tvheadend-launch
@@ -3,6 +3,7 @@
 LISTEN_IP=$(snapctl get tvh-ip)
 LISTEN_HTTP_PORT=$(snapctl get tvh-http-port)
 LISTEN_HTSP_PORT=$(snapctl get tvh-htsp-port)
+LISTEN_ON_IPV6=$(snapctl get tvh-listen-on-ipv6)
 
 ARGS=
 
@@ -14,6 +15,9 @@ if [ -n "$LISTEN_HTTP_PORT" ]; then
 fi
 if [ -n "$LISTEN_HTSP_PORT" ]; then
     ARGS="$ARGS --htsp_port $LISTEN_HTSP_PORT"
+fi
+if [ -n "$LISTEN_ON_IPV6" ]; then
+    ARGS="$ARGS --ipv6"
 fi
 
 if [ ! -d "$SNAP_DATA/accesscontrol" ]; then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,8 @@ description: >
   on the same computer. You can change the listening port and IP with
   `snapctl set tvheadend tvh-http-port=9981` and
   `snapctl set tvheadend tvh-ip=0.0.0.0`. You can also change the port for HTSP
-  streaming connections with `snapctl set tvheadend tvh-htsp-port=9982`
+  streaming connections with `snapctl set tvheadend tvh-htsp-port=9982`.
+  You can allow tvheadend to listen on IPv6 with `snapctl set tvheadend tvh-listen-on-ipv6=true`.
 
   OSCam's web interface is listening on port 8888 by default. You can change
   this by editing the file returned by `tvheadend.oscam-config`. e.g.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,10 +9,10 @@ description: >
   Once installed use your web browser to navigate to http://<IP-Address>:9981/.
   You can use 127.0.0.1 for the IP Address if your browser and tvheadend are
   on the same computer. You can change the listening port and IP with
-  `snapctl set tvheadend tvh-http-port=9981` and
-  `snapctl set tvheadend tvh-ip=0.0.0.0`. You can also change the port for HTSP
-  streaming connections with `snapctl set tvheadend tvh-htsp-port=9982`.
-  You can allow tvheadend to listen on IPv6 with `snapctl set tvheadend tvh-listen-on-ipv6=true`.
+  `snap set tvheadend tvh-http-port=9981` and
+  `snap set tvheadend tvh-ip=0.0.0.0`. You can also change the port for HTSP
+  streaming connections with `snap set tvheadend tvh-htsp-port=9982`.
+  You can allow tvheadend to listen on IPv6 with `snap set tvheadend tvh-listen-on-ipv6=true`.
 
   OSCam's web interface is listening on port 8888 by default. You can change
   this by editing the file returned by `tvheadend.oscam-config`. e.g.


### PR DESCRIPTION
Minor change to allow --ipv6 command line option to be passed through.